### PR TITLE
OlatLmsRestTemplate: also refresh auth token when receiving 403 FORBIDDEN

### DIFF
--- a/src/main/java/ch/ethz/seb/sebserver/webservice/servicelayer/lms/impl/olat/OlatLmsRestTemplate.java
+++ b/src/main/java/ch/ethz/seb/sebserver/webservice/servicelayer/lms/impl/olat/OlatLmsRestTemplate.java
@@ -55,7 +55,8 @@ public class OlatLmsRestTemplate extends RestTemplate {
                 ClientHttpResponse response = execution.execute(request, body);
                 log.debug("OLAT [regular API call] {} Headers: {}", response.getStatusCode(), response.getHeaders());
                 // If we get a 401, re-authenticate and try once more
-                if (response.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+                if (response.getStatusCode() == HttpStatus.UNAUTHORIZED ||
+                      response.getStatusCode() == HttpStatus.FORBIDDEN) {
                     authenticate();
                     request.getHeaders().set("X-OLAT-TOKEN", OlatLmsRestTemplate.this.token);
                     response = execution.execute(request, body);


### PR DESCRIPTION
As discussed, OLAT might reject an existing but expired token with a 403 instead of 401, so we also re-authenticate accordingly.