### PR TITLE
Rename Open Olat to OLAT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ SEB Server is a modern webservice with a REST API and a GUI service on top of it
 SEB Server provides a range of basic functionalities:
 
 - Built-in institutional multitenancy
-- Linking of multiple Learning Management Systems (LMS). Currently supported LMS: `Open edX <https://open.edx.org/>`_, `Moodle <https://moodle.org/>`_, `Open Olat <https://www.openolat.com/>`_, `ANS <https://ans.app/>`_
+- Linking of multiple Learning Management Systems (LMS). Currently supported LMS: `Open edX <https://open.edx.org/>`_, `Moodle <https://moodle.org/>`_, `OLAT <https://www.olat.org/>`_, `ANS <https://ans.app/>`_
 - Accessing the Course/Exam-API of a linked LMS to import a courses or exams for managing with SEB Server
 - Creation and administration of SEB Client Configurations that can be used to startup a SEB and that contains SEB Server connection information for a SEB Client
 - Creation and administration of SEB Exam Configurations that can be bound to an imported Exam to automatically configure a SEB Client that connects to an exam that is managed by SEB Server

--- a/docs/lmssetup.rst
+++ b/docs/lmssetup.rst
@@ -74,8 +74,8 @@ SEB Server internally. Use the **"Type"** selector to specify the type of the LM
 - **Ans Delft**: This type is to bind SEB Server with an `Ans Delft <https://ans.app/>`_ LMS/Assessment Tool. With the API credentials from an Ans Delft instance, SEB Server is able
   to connect to the Ans LMS/Assessment Tool and provide the common features for Course-Access, SEB Restriction and LMS/Assessment Tool User Session resolving.
   
-- **Open Olat**: This type is to bind SEB Server with an `Open Olat <https://www.openolat.com/>`_ LMS/Assessment Tool. With the API credentials from an Open Olat instance, SEB Server is able
-  to connect to the Olat LMS/Assessment Tool and provide the common features for Course-Access, SEB Restriction and LMS/Assessment Tool User Session resolving. For more information please contact the Olat Development-Team at `OpenOLAT UZH <https://www.zi.uzh.ch/en/teaching-and-research/software-elearning/olat.html>`_
+- **OLAT**: This type is to bind SEB Server with an `OLAT <https://www.olat.org/>`_ LMS/Assessment Tool. With the API credentials from an PéAT instance, SEB Server is able
+  to connect to the OLAT LMS/Assessment Tool and provide the common features for Course-Access, SEB Restriction and LMS/Assessment Tool User Session resolving. For more information please contact the OLAT Development-Team at `OLAT UZH <https://www.zi.uzh.ch/en/support/e-learning-and-examination/staff/olat.html>`_
 
 The **"LMS/Assessment Tool Server Address"** is the root URL to connect to the LMS/Assessment Tool server with HTTP over the Internet or intranet. This is usually the URL that is
 also used with the Browser to connect to the main page of the LMS/Assessment Tool system. And additionally the credentials that have been created with the creation of the :ref:`lms-api-account-label` has to be set in the LMS/Assessment Tool Setup the make the SEB Server

--- a/src/main/java/ch/ethz/seb/sebserver/gbl/model/user/UserFeatures.java
+++ b/src/main/java/ch/ethz/seb/sebserver/gbl/model/user/UserFeatures.java
@@ -35,7 +35,7 @@ public class UserFeatures {
         LMS_SETUP_MOODLE_PLUGIN("lms.setup.type.MOODLE_PLUGIN"),
         LMS_SETUP_OPEN_EDX("lms.setup.type.OPEN_EDX"),
         LMS_SETUP_ANS("lms.setup.type.ANS_DELFT"),
-        LMS_SETUP_OPEN_OLAT("lms.setup.type.OPEN_OLAT"),
+        LMS_SETUP_OLAT("lms.setup.type.OLAT"),
 
         QUIZ_LOOKUP("lms.quiz.lookup"),
 

--- a/src/main/resources/config/application-dev-ws.properties
+++ b/src/main/resources/config/application-dev-ws.properties
@@ -89,7 +89,7 @@ sebserver.feature.exam.seb.screenProctoring.bundled.sebserveraccount.username=SE
 #sebserver.feature.config.certificate.enabled=false
 #
 #sebserver.feature.lms.setup.type.ANS_DELFT.enabled=false
-#sebserver.feature.lms.setup.type.OPEN_OLAT.enabled=false
+#sebserver.feature.lms.setup.type.OLAT.enabled=false
 #
 #sebserver.feature.exam.ask.enabled=false
 #sebserver.feature.exam.seb.restriction.enabled=false

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -344,7 +344,7 @@ sebserver.lmssetup.type.MOODLE_PLUGIN=Moodle with SEB Server Plugin
 sebserver.lmssetup.type.MOODLE_PLUGIN.tooltip=Moodle with SEB Server integration plugin installed
 sebserver.lmssetup.type.OPEN_EDX=Open edX
 sebserver.lmssetup.type.ANS_DELFT=Ans Delft
-sebserver.lmssetup.type.OPEN_OLAT=Open OLAT
+sebserver.lmssetup.type.OPEN_OLAT=OLAT
 
 sebserver.lmssetup.list.actions=
 sebserver.lmssetup.list.action.no.modify.privilege=No Access: A Assessment Tool Setup from other institution cannot be modified.


### PR DESCRIPTION
Dear SEB Server team

Technically it is [OLAT](https://www.olat.org/) and not [OpenOlat](https://www.openolat.com/) that is supporting SEB Server.
So I changed it in the documentation and some code occurrences.

Best regards
Christian