### PR TITLE
Use OpenOlat endpoint to fetch exams

### DIFF
--- a/src/main/java/ch/ethz/seb/sebserver/webservice/servicelayer/lms/impl/olat/OlatLmsAPITemplate.java
+++ b/src/main/java/ch/ethz/seb/sebserver/webservice/servicelayer/lms/impl/olat/OlatLmsAPITemplate.java
@@ -276,7 +276,7 @@ public class OlatLmsAPITemplate extends AbstractCachedCourseAccess implements Lm
         final DateTime quizFromTime = (filterMap != null) ? filterMap.getQuizFromTime() : null;
         final long fromCutTime = (quizFromTime != null) ? Utils.toUnixTimeInSeconds(quizFromTime) : -1;
 
-        String url = "/restapi/assessment_modes/seb?";
+        String url = "/restapi/repo/assessmentmodes?";
         if (fromCutTime != -1) {
             url = String.format("%sdateFrom=%s&", url, fromCutTime);
         }
@@ -296,8 +296,8 @@ public class OlatLmsAPITemplate extends AbstractCachedCourseAccess implements Lm
                             lmsSetup.getLmsType(),
                             a.name,
                             a.description,
-                            Utils.toDateTimeUTC(a.dateFrom),
-                            Utils.toDateTimeUTC(a.dateTo),
+                            Utils.toDateTimeUTC(a.begin),
+                            Utils.toDateTimeUTC(a.end),
                             examUrl(a.repositoryEntryKey),
                             new HashMap<String, String>());
                 })
@@ -317,7 +317,7 @@ public class OlatLmsAPITemplate extends AbstractCachedCourseAccess implements Lm
 
     private QuizData quizById(final OlatLmsRestTemplate restTemplate, final String id) {
         final LmsSetup lmsSetup = this.apiTemplateDataSupplier.getLmsSetup();
-        final String url = String.format("/restapi/assessment_modes/%s", id);
+        final String url = String.format("/restapi/repo/assessmentmodes/%s", id);
         final AssessmentData a = this.apiGet(restTemplate, url, AssessmentData.class);
         return new QuizData(
                 String.format("%d", a.key),
@@ -326,8 +326,8 @@ public class OlatLmsAPITemplate extends AbstractCachedCourseAccess implements Lm
                 lmsSetup.getLmsType(),
                 a.name,
                 a.description,
-                Utils.toDateTimeUTC(a.dateFrom),
-                Utils.toDateTimeUTC(a.dateTo),
+                Utils.toDateTimeUTC(a.begin),
+                Utils.toDateTimeUTC(a.end),
                 examUrl(a.repositoryEntryKey),
                 new HashMap<String, String>());
     }

--- a/src/main/java/ch/ethz/seb/sebserver/webservice/servicelayer/lms/impl/olat/OlatLmsData.java
+++ b/src/main/java/ch/ethz/seb/sebserver/webservice/servicelayer/lms/impl/olat/OlatLmsData.java
@@ -8,6 +8,7 @@
 
 package ch.ethz.seb.sebserver.webservice.servicelayer.lms.impl.olat;
 
+import java.util.Date;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -20,9 +21,8 @@ public final class OlatLmsData {
         /*
          * OLAT API example:
          * {
-         * "courseName": "course 1",
-         * "dateFrom": 1624420800000,
-         * "dateTo": 1624658400000,
+         * "begin": 1624420800000,
+         * "end": 1624658400000,
          * "description": "",
          * "key": 6356992,
          * “repositoryEntryKey”: 462324,
@@ -33,9 +33,8 @@ public final class OlatLmsData {
         public long repositoryEntryKey;
         public String name;
         public String description;
-        public String courseName;
-        public long dateFrom;
-        public long dateTo;
+        public Long begin;
+        public Long end;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
SEB Server should be able to use OpenOlat's original endpoint to fetch exams.